### PR TITLE
adding flag that allows including nvidia power to tot power calculations

### DIFF
--- a/ipmimon.py
+++ b/ipmimon.py
@@ -34,6 +34,7 @@ class IpmiMon:
                         dcmi_power=False,
                         nvidia=-1,
                         g2 = -1,
+                        include_nvidia_in_tot_power = False,
                         debug=False):
 
         self.ip         = ip
@@ -48,6 +49,7 @@ class IpmiMon:
         self.dcmi_power = dcmi_power
         self.nvidia     = nvidia
         self.g2         = g2
+        self.include_nvidia_in_tot_power = include_nvidia_in_tot_power
         self.connected  = False
         self.consec_ipmi_errors = 0
         self.consec_nvid_errors = 0

--- a/ipmisession.py
+++ b/ipmisession.py
@@ -11,12 +11,13 @@ class IpmiSessionManager:
     collected session sensor data.
     """
 
-    def __init__(self, debug=False):
+    def __init__(self, include_nvidia_in_tot_power=False, debug=False):
 
         self.session_started    = False
         self.started            = {}
         self.sensors            = {}
         self.capture_sessions   = {}
+        self.include_nvidia_in_tot_power = include_nvidia_in_tot_power
         self.debug              = debug
 
     def start(self, dt, session_id):
@@ -104,8 +105,11 @@ class IpmiSessionManager:
         tot_power = 0
         for sensor_id in self.sensors.keys():
             if type(sensor_id)==type("") and sensor_id.startswith("nvidia"):
-                print("Warning: Skipping nvidia sensor in session total power compute")
-                continue
+                if self.include_nvidia_in_tot_power:
+                    print("Warning: Including nvidia sensor in session total power compute")
+                else:
+                    print("Warning: Skipping nvidia sensor in session total power compute")
+                    continue
             if type(sensor_id)==type("") and sensor_id.startswith("apu"):
                 print("Warning: Skipping apu sensor in session total power compute")
                 continue

--- a/tests/curl_test.sh
+++ b/tests/curl_test.sh
@@ -11,7 +11,7 @@ fi
 SID=$(curl http://localhost:${PORT}/session?start=1)
 if [ -z "${SID//[0-9]}" ]; then
     echo "Got session_id=${SID}"
-    sleep 10
+    sleep 5
     STATS=$(curl http://localhost:${PORT}/session?stop=all_stats&id=${SID})
     echo "Stats=${STATS}"
 else


### PR DESCRIPTION
What is this PR?
* adds a new flag "--include-nvidia-in-tot-power" which will include nvidia board(s) power into any total power calculations

Testing?
* yes, used tests/curl_test.sh to verify tot_power calculation using flag and without